### PR TITLE
added simple sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,24 @@ Docker RabbitMQ:
 	#t0> docker run --detach --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-management
 ```
 
-Consumer :
+####Consumer :
 ```
 	#t1> cd rabbit-mq-receiver
 	#t1> go run .\receive-mq.go
 ```
 
-Server : 
+####Server-API (Sender#1): 
+Simple API. Will push messages each time when endpoints are used. 
 ```
 	#t2> cd server
 	#t2> go run .\main.go
+```
+
+####Sender #2
+Simple sender which push messages to the same queue. 
+```
+#t3> cd .\rabbit-mq-sender\
+#t3> go run .\send-mq.go
 ```
 
 

--- a/rabbit-mq-sender/send-mq.go
+++ b/rabbit-mq-sender/send-mq.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"log"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+func failOnError(err error, msg string) {
+	if err != nil {
+		log.Panicf("%s: %s", msg, err)
+	}
+}
+
+func main() {
+	conn, err := amqp.Dial("amqp://guest:guest@localhost:5672/")
+	failOnError(err, "Failed to connect to RabbitMQ")
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	failOnError(err, "Failed to open a channel")
+	defer ch.Close()
+
+	q, err := ch.QueueDeclare(
+		"username-endpoint", // name
+		false,               // durable
+		false,               // delete when unused
+		false,               // exclusive
+		false,               // no-wait
+		nil,                 // arguments
+	)
+	failOnError(err, "Failed to declare a queue")
+
+	body := "Hello World!"
+	err = ch.Publish(
+		"",     // exchange
+		q.Name, // routing key
+		false,  // mandatory
+		false,  // immediate
+		amqp.Publishing{
+			ContentType: "text/plain",
+			Body:        []byte(body),
+		})
+	failOnError(err, "Failed to publish a message")
+	log.Printf(" [x] Sent %s\n", body)
+}


### PR DESCRIPTION
Now rabbit-mq consumer can get data from 2 senders : simple sender and API endpoints sender